### PR TITLE
Interface changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "ODEConvergenceTester"
 uuid = "42a5c2e1-f365-4540-8ca5-3684de3ecd95"
-authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
+authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 version = "0.1.0"
 
 [deps]
-ClimaTimeSteppers = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+ClimaTimeSteppers = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ODEConvergenceTester.jl
 
-A simple package for testing convergence rates for [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl)'s integrator object, see the [integrator interface](https://diffeq.sciml.ai/stable/basics/integrator/#integrator).
+A simple package for testing convergence rates for [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl)'s problems, see the [integrator interface](https://diffeq.sciml.ai/stable/basics/integrator/#integrator) for the input arguments to `OrdinaryDiffEq.init`.
 
 |||
 |---------------------:|:----------------------------------------------|
@@ -21,12 +21,15 @@ A simple package for testing convergence rates for [OrdinaryDiffEq.jl](https://g
 
 ```julia
 import OrdinaryDiffEq
-integrator = OrdinaryDiffEq.init(prob, alg; kwargs...) # You'll need your own.
+# Below, `prob` `alg` and `kwargs` are the same as those passed to:
+# integrator = OrdinaryDiffEq.init(prob, alg; kwargs...)
 
 import ODEConvergenceTester
 ODEConvergenceTester.refinement_study(
-    integrator;
+    prob,
+    alg;
     refinement_range = 1:3, # 2:4 is more fine than 1:3
+    kwargs...
 )
 ```
 

--- a/src/ODEConvergenceTester.jl
+++ b/src/ODEConvergenceTester.jl
@@ -1,6 +1,5 @@
 module ODEConvergenceTester
 
-import ClimaTimeSteppers
 import LinearAlgebra
 import Logging
 import OrdinaryDiffEq

--- a/src/ODEConvergenceTester.jl
+++ b/src/ODEConvergenceTester.jl
@@ -1,5 +1,6 @@
 module ODEConvergenceTester
 
+import ClimaTimeSteppers
 import LinearAlgebra
 import Logging
 import OrdinaryDiffEq
@@ -7,22 +8,24 @@ import OrdinaryDiffEq
 compute_err_norm_default(u::FT, v::FT) where {FT <: Real} = LinearAlgebra.norm(u - v)
 compute_err_norm_default(u, v) = LinearAlgebra.norm(u .- v)
 
-Base.@kwdef struct ConvergenceTestResults{FT}
-    p::Vector{FT}
+Base.@kwdef struct ConvergenceTestResults{FT,T}
+    computed_order::Vector{FT}
     err::Vector{FT}
     dts::Vector{FT}
-    p_expected::FT
+    expected_order::T
 end
 
 """
     refinement_study(
-        integrator₀,
+        problem,
+        alg,
         dts::Vector{<:Real};
         compute_err_norm::Function = compute_err_norm_default,
     )
 
     refinement_study(
-        integrator₀;
+        problem,
+        alg;
         compute_err_norm::Function = compute_err_norm_default,
         refinement_range::UnitRange = 1:3,
     )
@@ -30,7 +33,8 @@ end
 Estimates and reports the convergence rates.
 
 ## Arguments
- - `integrator₀` a OrdinaryDiffEq integrator
+ - `problem` a OrdinaryDiffEq problem
+ - `alg` an algorithm
  - `dts` a vector of timesteps
  - `compute_err_norm = (x,y) -> norm(x,y)` a function for computing
     the norm of the solution
@@ -73,10 +77,13 @@ Where
     http://www.grc.nasa.gov/WWW/wind/valid/tutorial/spatconv.html
 """
 function refinement_study(
-        integrator₀,
+        problem,
+        alg,
         dts::Vector{dtType};
+        expected_order = OrdinaryDiffEq.alg_order(alg),
         compute_err_norm::Function = compute_err_norm_default,
-        print_report::Bool = true,
+        verbose::Bool = false,
+        integrator_kwargs...
     ) where {dtType <: Real}
 
     n_refinements = length(dts)
@@ -86,7 +93,7 @@ function refinement_study(
 
     # Create deepcopy of integrators to prevent accidental mutation
     integrators = map(1:n_refinements) do n
-        deepcopy(integrator₀)
+        OrdinaryDiffEq.init(deepcopy(problem), deepcopy(alg); dt=dts[n], integrator_kwargs...)
     end
 
     # Refinement factors
@@ -95,15 +102,16 @@ function refinement_study(
     end
 
     # Compute new t_final such that n_steps[i]*dt[i] = t_final
-    t_final₀ = last(integrator₀.sol.prob.tspan)
+    t_final₀ = last(problem.tspan)
     n_steps₀ = round(t_final₀ / dts[1])
     n_steps = map(i -> n_steps₀ * 2^(i - 1), 1:n_refinements)
     t_final = map(enumerate(dts)) do (i, dt)
         n_steps[i] * dt
     end
 
-    if print_report
+    if verbose
         @info "------ Convergence parameters ------"
+        @info "tspan (original)          : $(problem.tspan)"
         @info "nsteps                    : $n_steps"
         @info "refinement factors        : $refinement_factor"
         @info "dts                       : $dts"
@@ -113,11 +121,18 @@ function refinement_study(
 
     for i in 1:n_refinements
         dt = dts[i]
-        OrdinaryDiffEq.set_proposed_dt!(integrators[i], dt)
-        print("@timing iteration $i:")
-        @time Logging.with_logger(Logging.NullLogger()) do
-            for n in 1:n_steps[i]
-                OrdinaryDiffEq.step!(integrators[i], dt)
+        if verbose
+            print("@timing iteration $i:")
+            @time Logging.with_logger(Logging.NullLogger()) do
+                for n in 1:n_steps[i]
+                    OrdinaryDiffEq.step!(integrators[i], dt)
+                end
+            end
+        else
+            Logging.with_logger(Logging.NullLogger()) do
+                for n in 1:n_steps[i]
+                    OrdinaryDiffEq.step!(integrators[i], dt)
+                end
             end
         end
         u = integrators[i].u
@@ -132,24 +147,26 @@ function refinement_study(
     end
 
     FT = eltype(p)
-    p_expected = FT(OrdinaryDiffEq.alg_order(integrator₀.sol.alg))
-    if print_report
+    if verbose
         @info "----- Convergence study output -----"
         @info "Errors                    : $(err)"
         @info "Convergence orders        : $(p)"
-        @info "Expected convergence order: $(p_expected)"
+        @info "Expected convergence order: $(expected_order)"
         @info "------------------------------------"
     end
-    return ConvergenceTestResults(; p, err, dts, p_expected)
+    return ConvergenceTestResults(; computed_order=p, err, dts, expected_order)
 end
 
 function refinement_study(
-        integrator₀;
+        problem,
+        alg;
+        expected_order = OrdinaryDiffEq.alg_order(alg),
         refinement_range::UnitRange = 1:3,
         compute_err_norm::Function = compute_err_norm_default,
-        print_report::Bool = true,
+        verbose::Bool = false,
+        integrator_kwargs...,
     )
-    t_final₀ = last(integrator₀.sol.prob.tspan)
+    t_final₀ = last(problem.tspan)
     # For this analysis, Δt must be ~ 2^n, so we must
     # find a scale that will result in a reasonable timestep:
     # 2^(scale) = t_final
@@ -163,10 +180,13 @@ function refinement_study(
         dt_max / (refinement_factor^(i - 1))
     end
     return refinement_study(
-        integrator₀,
+        problem,
+        alg,
         dts;
-        print_report=print_report,
-        compute_err_norm=compute_err_norm,
+        expected_order,
+        verbose,
+        compute_err_norm,
+        integrator_kwargs...,
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,22 +50,17 @@ all_algos = [Euler(), SSPRK22()]
     tc = ODEConvergenceTester.refinement_study
     for alg in all_algos
         for (i, prob) in enumerate(all_problems)
-            integrator = OrdinaryDiffEq.init(prob, alg; dt = Float64(0.1))
-            ctr = tc(integrator; refinement_range = 9:13, print_report = false)
-            @test last(ctr.p) ≈ OrdinaryDiffEq.alg_order(alg) rtol = 5e-2
+            expected_order = OrdinaryDiffEq.alg_order(alg)
+            ctr = tc(prob, alg; refinement_range = 9:13, verbose = false, expected_order)
+            @test last(ctr.computed_order) ≈ expected_order rtol = 5e-2
         end
     end
 
     # Make sure printing doesn't break:
-    integrator = OrdinaryDiffEq.init(
-        first(all_problems),
-        first(all_algos);
-        dt = Float64(0.1)
-    )
-    ctr = tc(integrator; refinement_range = 9:13)
+    ctr = tc(first(all_problems), first(all_algos); refinement_range = 9:13)
 
     a_err = "Need at least 3 runs to compute convergence order"
-    @test_throws AssertionError(a_err) tc(integrator; refinement_range = 1:2)
+    @test_throws AssertionError(a_err) tc(first(all_problems), first(all_algos); refinement_range = 1:2)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,13 @@ all_algos = [Euler(), SSPRK22()]
         end
     end
 
+    # test verbose option
+    alg = first(all_algos)
+    prob = first(all_problems)
+    expected_order = OrdinaryDiffEq.alg_order(alg)
+    ctr = tc(prob, alg; refinement_range = 9:13, verbose = true, expected_order)
+    @test last(ctr.computed_order) ≈ expected_order rtol = 5e-2
+
     # Make sure printing doesn't break:
     ctr = tc(first(all_problems), first(all_algos); refinement_range = 9:13)
 


### PR DESCRIPTION
This PR:
 - changes the interface to accept `OrdinaryDiffEq.init`'s arguments, rather than the integrator. This is much simpler, more intuitive, and no longer depends on `set_proposed_dt!`.