### PR TITLE
Use SciMLBase over OrdinaryDiffEq

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "ODEConvergenceTester"
 uuid = "42a5c2e1-f365-4540-8ca5-3684de3ecd95"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
-OrdinaryDiffEq = "5, 6"
+SciMLBase = "1"
 julia = "1.4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ODEConvergenceTester.jl
 
-A simple package for testing convergence rates for [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl)'s problems, see the [integrator interface](https://diffeq.sciml.ai/stable/basics/integrator/#integrator) for the input arguments to `OrdinaryDiffEq.init`.
+A simple package for testing convergence rates for [SciMLBase.jl](https://github.com/SciML/SciMLBase.jl)'s problems, see the [integrator interface](https://diffeq.sciml.ai/stable/basics/integrator/#integrator) for the input arguments to `SciMLBase.init`.
 
 |||
 |---------------------:|:----------------------------------------------|
@@ -20,9 +20,9 @@ A simple package for testing convergence rates for [OrdinaryDiffEq.jl](https://g
 ## Example
 
 ```julia
-import OrdinaryDiffEq
+import SciMLBase
 # Below, `prob` `alg` and `kwargs` are the same as those passed to:
-# integrator = OrdinaryDiffEq.init(prob, alg; kwargs...)
+# integrator = SciMLBase.init(prob, alg; kwargs...)
 
 import ODEConvergenceTester
 ODEConvergenceTester.refinement_study(

--- a/src/ODEConvergenceTester.jl
+++ b/src/ODEConvergenceTester.jl
@@ -2,7 +2,7 @@ module ODEConvergenceTester
 
 import LinearAlgebra
 import Logging
-import OrdinaryDiffEq
+import SciMLBase
 
 compute_err_norm_default(u::FT, v::FT) where {FT <: Real} = LinearAlgebra.norm(u - v)
 compute_err_norm_default(u, v) = LinearAlgebra.norm(u .- v)
@@ -32,7 +32,7 @@ end
 Estimates and reports the convergence rates.
 
 ## Arguments
- - `problem` a OrdinaryDiffEq problem
+ - `problem` a SciMLBase problem
  - `alg` an algorithm
  - `dts` a vector of timesteps
  - `compute_err_norm = (x,y) -> norm(x,y)` a function for computing
@@ -79,7 +79,7 @@ function refinement_study(
         problem,
         alg,
         dts::Vector{dtType};
-        expected_order = OrdinaryDiffEq.alg_order(alg),
+        expected_order = SciMLBase.alg_order(alg),
         compute_err_norm::Function = compute_err_norm_default,
         verbose::Bool = false,
         integrator_kwargs...
@@ -92,7 +92,7 @@ function refinement_study(
 
     # Create deepcopy of integrators to prevent accidental mutation
     integrators = map(1:n_refinements) do n
-        OrdinaryDiffEq.init(deepcopy(problem), deepcopy(alg); dt=dts[n], integrator_kwargs...)
+        SciMLBase.init(deepcopy(problem), deepcopy(alg); dt=dts[n], integrator_kwargs...)
     end
 
     # Refinement factors
@@ -124,13 +124,13 @@ function refinement_study(
             print("@timing iteration $i:")
             @time Logging.with_logger(Logging.NullLogger()) do
                 for n in 1:n_steps[i]
-                    OrdinaryDiffEq.step!(integrators[i], dt)
+                    SciMLBase.step!(integrators[i], dt)
                 end
             end
         else
             Logging.with_logger(Logging.NullLogger()) do
                 for n in 1:n_steps[i]
-                    OrdinaryDiffEq.step!(integrators[i], dt)
+                    SciMLBase.step!(integrators[i], dt)
                 end
             end
         end
@@ -159,7 +159,7 @@ end
 function refinement_study(
         problem,
         alg;
-        expected_order = OrdinaryDiffEq.alg_order(alg),
+        expected_order = SciMLBase.alg_order(alg),
         refinement_range::UnitRange = 1:3,
         compute_err_norm::Function = compute_err_norm_default,
         verbose::Bool = false,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,9 +3,11 @@ DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DiffEqDevTools = "2.29"
 DiffEqProblemLibrary = "4.15"
 OrdinaryDiffEq = "5.64, 6.6"
+SciMLBase = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,11 @@
 using Test
 import ODEConvergenceTester
+import OrdinaryDiffEq as ODE
 
 # These problem configurations were borrowed, and slightly modified, from
 # https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/test/algconvergence/ode_ssprk_tests.jl
 
-using OrdinaryDiffEq, DiffEqDevTools, Test, Random
+using SciMLBase, DiffEqDevTools, Test, Random
 using DiffEqProblemLibrary.ODEProblemLibrary: importodeproblems; importodeproblems()
 import DiffEqProblemLibrary.ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear
 
@@ -44,13 +45,15 @@ all_problems = [
     test_problem_ssp,
 ]
 
-all_algos = [Euler(), SSPRK22()]
+all_algos = [ODE.Euler(), ODE.SSPRK22()]
+SciMLBase.alg_order(::ODE.Euler) = 1
+SciMLBase.alg_order(::ODE.SSPRK22) = 2
 
 @testset "ODEConvergenceTester" begin
     tc = ODEConvergenceTester.refinement_study
     for alg in all_algos
         for (i, prob) in enumerate(all_problems)
-            expected_order = OrdinaryDiffEq.alg_order(alg)
+            expected_order = SciMLBase.alg_order(alg)
             ctr = tc(prob, alg; refinement_range = 9:13, verbose = false, expected_order)
             @test last(ctr.computed_order) ≈ expected_order rtol = 5e-2
         end
@@ -59,7 +62,7 @@ all_algos = [Euler(), SSPRK22()]
     # test verbose option
     alg = first(all_algos)
     prob = first(all_problems)
-    expected_order = OrdinaryDiffEq.alg_order(alg)
+    expected_order = SciMLBase.alg_order(alg)
     ctr = tc(prob, alg; refinement_range = 9:13, verbose = true, expected_order)
     @test last(ctr.computed_order) ≈ expected_order rtol = 5e-2
 


### PR DESCRIPTION
This PR switches to using SciMLBase from OrdinaryDiffEq, since SciMLBase is a lighter dependency.